### PR TITLE
Servers attribute

### DIFF
--- a/grasshopper/lib/renderer.js
+++ b/grasshopper/lib/renderer.js
@@ -209,6 +209,10 @@ RequestContext.prototype.renderText = function(text) {
     this.send(text);
 };
 
+RequestContext.prototype.renderNothing = function() {
+    this.send("");
+};
+
 RequestContext.prototype.send = function(text) {
     this.writeHead();
     if(this.request.method != 'HEAD') {

--- a/grasshopper/lib/renderer.js
+++ b/grasshopper/lib/renderer.js
@@ -209,10 +209,6 @@ RequestContext.prototype.renderText = function(text) {
     this.send(text);
 };
 
-RequestContext.prototype.renderNothing = function() {
-    this.send("");
-};
-
 RequestContext.prototype.send = function(text) {
     this.writeHead();
     if(this.request.method != 'HEAD') {

--- a/grasshopper/lib/routes.js
+++ b/grasshopper/lib/routes.js
@@ -85,6 +85,10 @@ exports.api.getSecureController = function(method, path) {
     return secureRoutes[method + ':' + path];
 };
 
+exports.api.servers = function() {
+	return servers;
+};
+
 function redirectSecure() {
     var hostHeader = this.request.headers['host'];
     var redirectHost = hostHeader;

--- a/grasshopper/lib/routes.js
+++ b/grasshopper/lib/routes.js
@@ -86,7 +86,7 @@ exports.api.getSecureController = function(method, path) {
 };
 
 exports.api.servers = function() {
-	return servers;
+    return servers;
 };
 
 function redirectSecure() {


### PR DESCRIPTION
Hi,

sometimes it's very needed to access the http server object directly. Therefore I implemented the servers attribute in routes.js

For example when I use socket.IO I can use it with

var io = io.listen(gh.servers()[0]);
