### PR TITLE
Streamer bug with bufferSize

### DIFF
--- a/grasshopper/lib/ghp.js
+++ b/grasshopper/lib/ghp.js
@@ -158,10 +158,11 @@ Streamer.prototype.write = function(str) {
 
         while(this._bufContentLen +
                 (tmpBuffer.length - currentOffset) >= bufferSize) {
+            var remaining = bufferSize - this._bufContentLen;
             tmpBuffer.copy(this._out, this._bufContentLen, currentOffset,
-                            currentOffset + bufferSize);
-            currentOffset += bufferSize;
-            this._bufContentLen += bufferSize;
+                            currentOffset + remaining);
+            currentOffset += remaining;
+            this._bufContentLen += remaining;
             this.flush();
         }
 

--- a/test/fixtures/ghp/too_big.txt
+++ b/test/fixtures/ghp/too_big.txt
@@ -1,0 +1,6 @@
+offset<% 
+var tooBig = '';
+for (var i = 0; i <= 8200; i++) { 
+	tooBig += 'A';
+} 
+%><%=tooBig%>

--- a/test/simple/ghp-test.js
+++ b/test/simple/ghp-test.js
@@ -71,6 +71,14 @@ suite.tests = {
         assert.equal(response.out, '\n');
         assert.ok(response.ended);
         next();
+    },
+    
+    'Too big template' : function(next) {
+        var response = new MockResponse();
+        ghp.fill('../fixtures/ghp/too_big.txt', response, {}, 'utf8', '../fixtures/ghp', 'txt');
+        assert.equal(response.out.length, 8207);
+        assert.ok(response.ended);
+        next();
     }
 };
 


### PR DESCRIPTION
Hi Chandru - 

I ran into a bug where if I have X bytes already in the Streamer's buffer, and then I try to add Y bytes such that X + Y > bufferSize, I get an error - specifically:

end cannot be longer than parent.length
    at Buffer.toString (buffer:36:19)
    at Streamer.flush (/Users/dave/Documents/Misc/git/grasshopper/grasshopper/lib/ghp.js:175:36)
    at Streamer.write (/Users/dave/Documents/Misc/git/grasshopper/grasshopper/lib/ghp.js:166:18)
    at ../fixtures/ghp/too_big.txt:6:19
    at Object.fill (/Users/dave/Documents/Misc/git/grasshopper/grasshopper/lib/ghp.js:36:120)
    at Object.Too big template (/Users/dave/Documents/Misc/git/grasshopper/test/simple/ghp-test.js:78:13)
    at /Users/dave/Documents/Misc/git/grasshopper/test/common/ghunit.js:46:35
    at Object.setup (/Users/dave/Documents/Misc/git/grasshopper/test/common/ghunit.js:9:44)
    at runTest (/Users/dave/Documents/Misc/git/grasshopper/test/common/ghunit.js:45:15)
    at nextTest (/Users/dave/Documents/Misc/git/grasshopper/test/common/ghunit.js:30:13)

I've included a test case for this as well as the fix.

Thanks!
David
